### PR TITLE
feat(shell-ui-kit): proposal card failed status style

### DIFF
--- a/libs/shell/governance/src/lib/proposal-details-page.tsx
+++ b/libs/shell/governance/src/lib/proposal-details-page.tsx
@@ -169,7 +169,8 @@ function ProposalDetailsMobile({
           <div>
             {(proposalDetails.status === ProposalStatus.Voting ||
               proposalDetails.status === ProposalStatus.Passed ||
-              proposalDetails.status === ProposalStatus.Rejected) && (
+              proposalDetails.status === ProposalStatus.Rejected ||
+              proposalDetails.status === ProposalStatus.Failed) && (
               <div>
                 <ProposalVoteProgress
                   results={proposalTally}
@@ -192,6 +193,7 @@ function ProposalDetailsMobile({
           <ProposalTurnoutQuorum
             turnout={formatNumber(turnout, 2, 2)}
             quorum={formatNumber(quorum, 2, 2)}
+            status={proposalDetails.status}
           />
 
           {(proposalDetails.status === ProposalStatus.Deposit ||
@@ -254,7 +256,8 @@ export function ProposalDetailsComponent({
   const [showDates, setShowDates] = useState(
     Boolean(
       proposalDetails.status === ProposalStatus.Passed ||
-        proposalDetails.status === ProposalStatus.Rejected,
+        proposalDetails.status === ProposalStatus.Rejected ||
+        proposalDetails.status === ProposalStatus.Failed,
     ),
   );
   const { data: userVote } = useProposalVoteQuery(
@@ -268,6 +271,7 @@ export function ProposalDetailsComponent({
 
   //   return now < voteStart && isWalletConnected;
   // }, [isWalletConnected, proposalDetails]);
+
   const totalDeposit = useMemo(() => {
     if (proposalDetails.total_deposit.length === 0) {
       return 0;
@@ -278,6 +282,7 @@ export function ProposalDetailsComponent({
       10,
     );
   }, [proposalDetails]);
+
   const minDeposit = useMemo(() => {
     if (govParams.deposit_params.min_deposit.length === 0) {
       return 0;
@@ -288,6 +293,7 @@ export function ProposalDetailsComponent({
       10,
     );
   }, [govParams]);
+
   const isTablet = useMediaQuery({
     query: `(max-width: 1023px)`,
   });
@@ -537,7 +543,8 @@ export function ProposalDetailsComponent({
 
                   {(proposalDetails.status === ProposalStatus.Voting ||
                     proposalDetails.status === ProposalStatus.Passed ||
-                    proposalDetails.status === ProposalStatus.Rejected) && (
+                    proposalDetails.status === ProposalStatus.Rejected ||
+                    proposalDetails.status === ProposalStatus.Failed) && (
                     <div className="flex flex-col gap-[24px]">
                       <div>
                         <ProposalVoteProgress
@@ -550,10 +557,12 @@ export function ProposalDetailsComponent({
                       <ProposalTurnoutQuorum
                         turnout={formatNumber(turnout, 2, 2)}
                         quorum={formatNumber(quorum, 2, 2)}
+                        status={proposalDetails.status}
                       />
 
                       {(proposalDetails.status === ProposalStatus.Passed ||
-                        proposalDetails.status === ProposalStatus.Rejected) && (
+                        proposalDetails.status === ProposalStatus.Rejected ||
+                        proposalDetails.status === ProposalStatus.Failed) && (
                         <div>
                           {showDates ? (
                             <table>
@@ -565,7 +574,14 @@ export function ProposalDetailsComponent({
                                     </ProposalDatesText>
                                   </td>
                                   <td>
-                                    <ProposalDatesText className="text-white">
+                                    <ProposalDatesText
+                                      className={clsx(
+                                        proposalDetails.status ===
+                                          ProposalStatus.Failed
+                                          ? 'text-white/50'
+                                          : 'text-white',
+                                      )}
+                                    >
                                       {formatDate(
                                         new Date(proposalDetails.submit_time),
                                       )}
@@ -579,7 +595,14 @@ export function ProposalDetailsComponent({
                                     </ProposalDatesText>
                                   </td>
                                   <td>
-                                    <ProposalDatesText className="text-white">
+                                    <ProposalDatesText
+                                      className={clsx(
+                                        proposalDetails.status ===
+                                          ProposalStatus.Failed
+                                          ? 'text-white/50'
+                                          : 'text-white',
+                                      )}
+                                    >
                                       {formatDate(
                                         new Date(
                                           proposalDetails.deposit_end_time,
@@ -595,7 +618,14 @@ export function ProposalDetailsComponent({
                                     </ProposalDatesText>
                                   </td>
                                   <td>
-                                    <ProposalDatesText className="text-white">
+                                    <ProposalDatesText
+                                      className={clsx(
+                                        proposalDetails.status ===
+                                          ProposalStatus.Failed
+                                          ? 'text-white/50'
+                                          : 'text-white',
+                                      )}
+                                    >
                                       {formatDate(
                                         new Date(
                                           proposalDetails.voting_start_time,
@@ -611,7 +641,14 @@ export function ProposalDetailsComponent({
                                     </ProposalDatesText>
                                   </td>
                                   <td>
-                                    <ProposalDatesText className="text-white">
+                                    <ProposalDatesText
+                                      className={clsx(
+                                        proposalDetails.status ===
+                                          ProposalStatus.Failed
+                                          ? 'text-white/50'
+                                          : 'text-white',
+                                      )}
+                                    >
                                       {formatDate(
                                         new Date(
                                           proposalDetails.voting_end_time,
@@ -753,14 +790,28 @@ function ProposalTurnoutQuorumBlock({
 function ProposalTurnoutQuorum({
   turnout,
   quorum,
+  status,
 }: {
   turnout: string;
   quorum: string;
+  status: ProposalStatus;
 }) {
   return (
     <div className="flex flex-row gap-[16px]">
-      <ProposalTurnoutQuorumBlock title="Turnout" value={turnout} />
-      <ProposalTurnoutQuorumBlock title="Quorum" value={quorum} />
+      <ProposalTurnoutQuorumBlock
+        title="Turnout"
+        value={turnout}
+        valueClassName={clsx(
+          status === ProposalStatus.Failed && 'text-white/50',
+        )}
+      />
+      <ProposalTurnoutQuorumBlock
+        title="Quorum"
+        value={quorum}
+        valueClassName={clsx(
+          status === ProposalStatus.Failed && 'text-white/50',
+        )}
+      />
     </div>
   );
 }

--- a/libs/shell/governance/src/lib/proposal-details-page.tsx
+++ b/libs/shell/governance/src/lib/proposal-details-page.tsx
@@ -193,7 +193,7 @@ function ProposalDetailsMobile({
           <ProposalTurnoutQuorum
             turnout={formatNumber(turnout, 2, 2)}
             quorum={formatNumber(quorum, 2, 2)}
-            status={proposalDetails.status}
+            status={proposalDetails.status as ProposalStatus}
           />
 
           {(proposalDetails.status === ProposalStatus.Deposit ||

--- a/libs/shell/ui-kit/src/components/card/card.tsx
+++ b/libs/shell/ui-kit/src/components/card/card.tsx
@@ -8,7 +8,7 @@ export function Card({
   return (
     <div
       className={clsx(
-        'cursor-pointer rounded-lg border-[1.5px] border-[#ffffff3d] bg-transparent p-[16px] transition-colors duration-150 ease-out hover:border-[#EC5728] lg:p-[28px]',
+        'cursor-pointer rounded-lg border-[1.5px] border-[#ffffff3d] bg-transparent p-[16px] transition-colors duration-150 ease-out hover:border-[#EC5728] md:min-h-[388px] lg:p-[28px]',
         className,
       )}
     >

--- a/libs/shell/ui-kit/src/components/card/card.tsx
+++ b/libs/shell/ui-kit/src/components/card/card.tsx
@@ -24,7 +24,7 @@ export function CardHeading({
   return (
     <div
       className={clsx(
-        'font-guise text-[14px] font-[500] leading-[22px] text-white md:text-[17px] md:leading-[26px] lg:text-[18px] lg:leading-[28px]',
+        'font-guise text-[14px] font-[500] leading-[22px] md:text-[17px] md:leading-[26px] lg:text-[18px] lg:leading-[28px]',
         className,
       )}
     >

--- a/libs/shell/ui-kit/src/components/card/card.tsx
+++ b/libs/shell/ui-kit/src/components/card/card.tsx
@@ -24,7 +24,7 @@ export function CardHeading({
   return (
     <div
       className={clsx(
-        'font-guise text-[14px] font-[500] leading-[22px] md:text-[17px] md:leading-[26px] lg:text-[18px] lg:leading-[28px]',
+        'font-guise text-[14px] font-[500] leading-[22px] text-white md:text-[17px] md:leading-[26px] lg:text-[18px] lg:leading-[28px]',
         className,
       )}
     >

--- a/libs/shell/ui-kit/src/components/info-block/info-block.tsx
+++ b/libs/shell/ui-kit/src/components/info-block/info-block.tsx
@@ -1,9 +1,11 @@
 import { PropsWithChildren } from 'react';
+import clsx from 'clsx';
 
 export function InfoBlock({
   title,
   children,
-}: PropsWithChildren<{ title?: string }>) {
+  className,
+}: PropsWithChildren<{ title?: string; className?: string }>) {
   return (
     <div className="flex flex-col gap-[4px]">
       {title && (
@@ -11,7 +13,12 @@ export function InfoBlock({
           {title}
         </div>
       )}
-      <div className="text-[12px] font-[500] leading-[18px] text-white md:text-[14px] md:leading-[22px]">
+      <div
+        className={clsx(
+          'text-[12px] font-[500] leading-[18px] md:text-[14px] md:leading-[22px]',
+          className,
+        )}
+      >
         {children}
       </div>
     </div>

--- a/libs/shell/ui-kit/src/components/info-block/info-block.tsx
+++ b/libs/shell/ui-kit/src/components/info-block/info-block.tsx
@@ -15,7 +15,7 @@ export function InfoBlock({
       )}
       <div
         className={clsx(
-          'text-[12px] font-[500] leading-[18px] md:text-[14px] md:leading-[22px]',
+          'text-[12px] font-[500] leading-[18px] text-white md:text-[14px] md:leading-[22px]',
           className,
         )}
       >

--- a/libs/shell/ui-kit/src/components/proposal-card/proposal-card.tsx
+++ b/libs/shell/ui-kit/src/components/proposal-card/proposal-card.tsx
@@ -67,9 +67,7 @@ export function ProposalCard({
               <CardHeading
                 className={clsx(
                   'line-clamp-2 h-[56px]',
-                  status === ProposalStatusEnum.Failed
-                    ? 'text-white/50'
-                    : 'text-white',
+                  status === ProposalStatusEnum.Failed && '!text-white/50',
                 )}
               >
                 {title}
@@ -101,9 +99,7 @@ export function ProposalCard({
                   <InfoBlock
                     title="Voting start"
                     className={clsx(
-                      status === ProposalStatusEnum.Failed
-                        ? 'text-white/50'
-                        : 'text-white',
+                      status === ProposalStatusEnum.Failed && '!text-white/50',
                     )}
                   >
                     {formatDate(votingStartDate)}
@@ -113,9 +109,7 @@ export function ProposalCard({
                   <InfoBlock
                     title="Voting end"
                     className={clsx(
-                      status === ProposalStatusEnum.Failed
-                        ? 'text-white/50'
-                        : 'text-white',
+                      status === ProposalStatusEnum.Failed && '!text-white/50',
                     )}
                   >
                     {formatDate(votingEndDate)}

--- a/libs/shell/ui-kit/src/components/proposal-card/proposal-card.tsx
+++ b/libs/shell/ui-kit/src/components/proposal-card/proposal-card.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { ProposalStatus as ProposalStatusEnum } from '@evmos/provider';
+import clsx from 'clsx';
 import { formatDate } from '../../utils/format-date';
 import { Card, CardHeading } from '../card/card';
 import { InfoBlock } from '../info-block/info-block';
@@ -63,7 +64,14 @@ export function ProposalCard({
               {type}
             </div>
             <div>
-              <CardHeading className="line-clamp-2 h-[56px]">
+              <CardHeading
+                className={clsx(
+                  'line-clamp-2 h-[56px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'text-white/50'
+                    : 'text-white',
+                )}
+              >
                 {title}
               </CardHeading>
             </div>
@@ -85,16 +93,31 @@ export function ProposalCard({
             />
           )}
           {(status === ProposalStatusEnum.Rejected ||
-            status === ProposalStatusEnum.Passed) &&
+            status === ProposalStatusEnum.Passed ||
+            status === ProposalStatusEnum.Failed) &&
             (votingStartDate || votingEndDate) && (
               <div className="my-[2px] flex flex-row items-center gap-[32px] md:my-0">
                 {votingStartDate && (
-                  <InfoBlock title="Voting start">
+                  <InfoBlock
+                    title="Voting start"
+                    className={clsx(
+                      status === ProposalStatusEnum.Failed
+                        ? 'text-white/50'
+                        : 'text-white',
+                    )}
+                  >
                     {formatDate(votingStartDate)}
                   </InfoBlock>
                 )}
                 {votingEndDate && (
-                  <InfoBlock title="Voting end">
+                  <InfoBlock
+                    title="Voting end"
+                    className={clsx(
+                      status === ProposalStatusEnum.Failed
+                        ? 'text-white/50'
+                        : 'text-white',
+                    )}
+                  >
                     {formatDate(votingEndDate)}
                   </InfoBlock>
                 )}
@@ -111,7 +134,8 @@ export function ProposalCard({
           )}
           {(status === ProposalStatusEnum.Voting ||
             status === ProposalStatusEnum.Rejected ||
-            status === ProposalStatusEnum.Passed) && (
+            status === ProposalStatusEnum.Passed ||
+            status === ProposalStatusEnum.Failed) && (
             <ProposalVoteProgress
               results={results}
               status={status}

--- a/libs/shell/ui-kit/src/components/proposal-status/proposal-status.tsx
+++ b/libs/shell/ui-kit/src/components/proposal-status/proposal-status.tsx
@@ -78,6 +78,21 @@ export function ProposalStatus({
           <div>Deposit Period</div>
         </div>
       );
+    case ProposalStatusEnum.Failed:
+      return (
+        <div className={clsx('bg-white/[8%] text-white', baseClassName)}>
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M10 11.1785L14.4108 15.5893L15.5893 14.4108L11.1785 10L15.5893 5.58928L14.4108 4.41077L10 8.82151L5.58928 4.41077L4.41077 5.58928L8.82151 10L4.41077 14.4108L5.58928 15.5893L10 11.1785Z"
+              fill="currentColor"
+            />
+          </svg>
+
+          <div>Failed</div>
+        </div>
+      );
     default:
       return <div>{status}</div>;
   }

--- a/libs/shell/ui-kit/src/components/proposal-vote-progress/proposal-vote-progress.tsx
+++ b/libs/shell/ui-kit/src/components/proposal-vote-progress/proposal-vote-progress.tsx
@@ -88,7 +88,14 @@ export function ProposalVoteProgress({
     <div className="flex w-full flex-col space-y-2">
       <div className="space-y-[8px]">
         <div className="flex items-center space-x-[12px]">
-          <CardText className="text-[13px] leading-[20px] lg:text-[16px] lg:leading-[26px]">
+          <CardText
+            className={clsx(
+              'text-[13px] leading-[20px] lg:text-[16px] lg:leading-[26px]',
+              status === ProposalStatusEnum.Failed
+                ? 'text-white/50'
+                : 'text-white',
+            )}
+          >
             {status === ProposalStatusEnum.Voting
               ? 'Voting status'
               : 'Voting results'}
@@ -122,8 +129,15 @@ export function ProposalVoteProgress({
           )}
         </div>
 
-        {total === 0 ? (
-          <div className="relative h-[8px] overflow-hidden rounded-[4px] bg-[#FFFFFF26]"></div>
+        {total === 0 || status === ProposalStatusEnum.Failed ? (
+          <div
+            className={clsx(
+              'relative h-[8px] overflow-hidden rounded-[4px] ',
+              status === ProposalStatusEnum.Failed
+                ? 'bg-white/15'
+                : 'bg-[#FFFFFF26]',
+            )}
+          />
         ) : (
           <div className="relative flex h-[8px] w-full flex-row space-x-[4px] overflow-hidden">
             {yesPercents !== 0 && (
@@ -172,68 +186,148 @@ export function ProposalVoteProgress({
         )}
 
         <div className="flex flex-wrap items-center gap-x-3">
-          {Boolean(yesPercents && yesPercents > 0) && (
+          <div className="flex items-center">
             <div className="flex items-center">
-              <div className="flex items-center">
-                <div className="mb-[-2px] mr-[4px] h-2 w-2 rounded-full bg-[#01B26E] lg:mb-[-3px]" />
-                <div className="mr-[2px]">
-                  <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                    Yes
-                  </CardText>
-                </div>
-                <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                  {yesPercents.toFixed(2)}%
+              <div
+                className={clsx(
+                  'mb-[-2px] mr-[4px] h-2 w-2 rounded-full lg:mb-[-3px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'bg-white/50'
+                    : 'bg-[#01B26E]',
+                )}
+              />
+              <div className="mr-[2px]">
+                <CardText
+                  className={clsx(
+                    'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                    status === ProposalStatusEnum.Failed
+                      ? 'text-white/50'
+                      : 'text-white',
+                  )}
+                >
+                  Yes
                 </CardText>
               </div>
-            </div>
-          )}
-          {Boolean(noPercents && noPercents > 0) && (
-            <div className="flex items-center">
-              <div className="flex items-center">
-                <div className="mb-[-2px] mr-[4px] h-2 w-2 rounded-full bg-[#FF5454] lg:mb-[-3px]" />
-                <div className="mr-[2px]">
-                  <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                    No
-                  </CardText>
-                </div>
-              </div>
-              <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                {noPercents.toFixed(2)}%
+              <CardText
+                className={clsx(
+                  'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'text-white/50'
+                    : 'text-white',
+                )}
+              >
+                {yesPercents.toFixed(2)}%
               </CardText>
             </div>
-          )}
+          </div>
 
-          {Boolean(abstainPercents && abstainPercents > 0) && (
+          <div className="flex items-center">
             <div className="flex items-center">
-              <div className="flex items-center">
-                <div className="mb-[-2px] mr-[4px] h-2 w-2 rounded-full bg-[#AAABB2] lg:mb-[-3px]" />
-                <div className="mr-[2px]">
-                  <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                    Abstain
-                  </CardText>
-                </div>
-                <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                  {abstainPercents.toFixed(2)}%
+              <div
+                className={clsx(
+                  'mb-[-2px] mr-[4px] h-2 w-2 rounded-full lg:mb-[-3px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'bg-white/50'
+                    : 'bg-[#FF5454]',
+                )}
+              />
+              <div className="mr-[2px]">
+                <CardText
+                  className={clsx(
+                    'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                    status === ProposalStatusEnum.Failed
+                      ? 'text-white/50'
+                      : 'text-white',
+                  )}
+                >
+                  No
                 </CardText>
               </div>
             </div>
-          )}
+            <CardText
+              className={clsx(
+                'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                status === ProposalStatusEnum.Failed
+                  ? 'text-white/50'
+                  : 'text-white',
+              )}
+            >
+              {noPercents.toFixed(2)}%
+            </CardText>
+          </div>
 
-          {Boolean(vetoPercents && vetoPercents > 0) && (
+          <div className="flex items-center">
             <div className="flex items-center">
-              <div className="flex flex-row items-center">
-                <div className="mb-[-2px] mr-[4px] h-2 w-2 rounded-full bg-yellow-500 lg:mb-[-3px]" />
-                <div className="mr-[2px]">
-                  <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                    No with veto
-                  </CardText>
-                </div>
-                <CardText className="text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]">
-                  {vetoPercents.toFixed(2)}%
+              <div
+                className={clsx(
+                  'mb-[-2px] mr-[4px] h-2 w-2 rounded-full lg:mb-[-3px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'bg-white/50'
+                    : 'bg-[#AAABB2]',
+                )}
+              />
+              <div className="mr-[2px]">
+                <CardText
+                  className={clsx(
+                    'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                    status === ProposalStatusEnum.Failed
+                      ? 'text-white/50'
+                      : 'text-white',
+                  )}
+                >
+                  Abstain
                 </CardText>
               </div>
+              <CardText
+                className={clsx(
+                  'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'text-white/50'
+                    : 'text-white',
+                )}
+              >
+                {status === ProposalStatusEnum.Failed
+                  ? 0
+                  : abstainPercents.toFixed(2)}
+                %
+              </CardText>
             </div>
-          )}
+          </div>
+
+          <div className="flex items-center">
+            <div className="flex flex-row items-center">
+              <div
+                className={clsx(
+                  'mb-[-2px] mr-[4px] h-2 w-2 rounded-full lg:mb-[-3px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'bg-white/50'
+                    : 'bg-[#E3A13F]',
+                )}
+              />
+              <div className="mr-[2px]">
+                <CardText
+                  className={clsx(
+                    'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                    status === ProposalStatusEnum.Failed
+                      ? 'text-white/50'
+                      : 'text-white',
+                  )}
+                >
+                  No with veto
+                </CardText>
+              </div>
+              <CardText
+                className={clsx(
+                  'text-[12px] leading-[1.5em] lg:text-[14px] lg:leading-[22px]',
+                  status === ProposalStatusEnum.Failed
+                    ? 'text-white/50'
+                    : 'text-white',
+                )}
+              >
+                {vetoPercents.toFixed(2)}%
+              </CardText>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### This is how the rejected proposal card looks in the storybook:

<img width="936" alt="Screenshot 2024-05-31 at 6 13 44 AM" src="https://github.com/haqq-network/frontend/assets/88910027/89e4476a-1f2d-4bd8-8c2e-dd47f235d012">

### fix: proposal card height in tablet resolution:

<img width="846" alt="Screenshot 2024-05-31 at 6 29 27 AM" src="https://github.com/haqq-network/frontend/assets/88910027/0b6d84ea-3067-4fce-b999-900f92ad291c">
<img width="891" alt="Screenshot 2024-05-31 at 6 29 43 AM" src="https://github.com/haqq-network/frontend/assets/88910027/087c6e55-bd58-4e6c-bfce-3d9bcd0935e7">
